### PR TITLE
Unsafe jquery plugin

### DIFF
--- a/SiteAssets/pages/3.0/scripts/jquery.multiselect.js
+++ b/SiteAssets/pages/3.0/scripts/jquery.multiselect.js
@@ -89,8 +89,15 @@
                 maxWidth = instance.options.width;
             }
             else if( typeof instance.options.width == 'string' ) {
-                $( instance.options.width ).css( 'position', 'relative' );
-                maxWidth = '100%';
+                // $( instance.options.width ).css( 'position', 'relative' );
+                // maxWidth = '100%';
+                var element = $(document).find(instance.options.width);
+                if (element.length) {
+                    element.css('position', 'relative');
+                    maxWidth = '100%';
+                } else {
+                    console.warn('Invalid CSS selector provided for width option.');
+                }
             }
             else {
                 optionsWrap.parent().css( 'position', 'relative' );


### PR DESCRIPTION
Sanitization: By using $(document).find(instance.options.width), ensure that instance.options.width is treated as a CSS selector.
Validation: The code checks if the element exists before applying the CSS, which prevents potential errors or security issues.

This approach helps mitigate the risk of cross-site scripting (XSS) attacks by ensuring that user input is properly sanitized and validated.