### PR TITLE
removing the pop up saying safetibase has been updated

### DIFF
--- a/SiteAssets/pages/3.0/scripts/INIT.PAGE.js
+++ b/SiteAssets/pages/3.0/scripts/INIT.PAGE.js
@@ -1,6 +1,5 @@
 $(document).ready(function() {
     SP.SOD.executeFunc('sp.js', 'SP.ClientContext', init);
-    toastr.success('<br/>Safetibase has been upgraded to improve functionality. Loading should be smoother, new features have been added and the interface can be easily configured to meet project needs. For a complete list of the upgrades please see the release note <a href="https://safetibase.org/release-notes" target="_blank"><u>here</u></a>.', "Safetibase Upgrade", { timeOut: 0, extendedTimeOut: 0, closeButton: true, positionClass: "toast-top-center", opacity: 1});
 });
 
 function init(refresh) {


### PR DESCRIPTION
removed a line of code to stop a pop up that notifies the user that safetibase has been updated